### PR TITLE
Update change types to support browser & node

### DIFF
--- a/lib/observed.js
+++ b/lib/observed.js
@@ -156,9 +156,9 @@ function onchange (parent, prefix) {
         ? prefix + '.' + name
         : name
 
-      if ('new' == type && null != value && 'object' == typeof value) {
+      if (('new' == type || 'add' == type) && null != value && 'object' == typeof value) {
         new Observable(value, parent, path);
-      } else if ('deleted' == type && 'object' == typeof change.oldValue) {
+      } else if (('deleted' == type || 'delete' == type) && 'object' == typeof change.oldValue) {
         parent._remove(change.oldValue);
       }
 


### PR DESCRIPTION
Node seems to use different change types than the [Harmony spec](http://wiki.ecmascript.org/doku.php?id=harmony:observe_api_usage) specifies, while Chrome follows the spec.

This patch updates the library to work in the browser and in Node.
