### PR TITLE
use Object.keys()

### DIFF
--- a/lib/observed.js
+++ b/lib/observed.js
@@ -92,7 +92,7 @@ Observable.prototype._walk = function (parent, prefix) {
   var object = this.subject;
 
   // keys?
-  Object.getOwnPropertyNames(object).forEach(function (name) {
+  Object.keys(object).forEach(function (name) {
     var value = object[name];
 
     if ('object' != typeof value) return;


### PR DESCRIPTION
To more closely match `Object.observe` behavior, don't walk non-enumerable properties.
