### PR TITLE
Continue observing nested objects that change.

### DIFF
--- a/lib/observed.js
+++ b/lib/observed.js
@@ -177,7 +177,19 @@ function onchange (parent, prefix) {
         new Observable(value, parent, path);
       } else if ('delete' == type && 'object' == typeof change.oldValue) {
         parent._remove(change.oldValue);
-      }
+      } else if ('update' == type) {
+        if(change.oldValue != value) {
+          // If we removed an object, then remove the observer too.
+          if('object' == typeof change.oldValue) {
+            parent._remove(change.oldValue);
+          }
+          
+          // If we changed this with another object, re-observe it.
+          if('object' == typeof value) {
+            new Observable(value, parent, path);
+          }
+        } 
+      } 
 
       change = new Change(path, change);
       parent.emit(type, change);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "observed",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "observeable objects the way you want em",
   "keywords": [
     "observe",

--- a/test/index.js
+++ b/test/index.js
@@ -234,6 +234,21 @@ describe('observed', function(){
         assert.strictEqual(true, change.oldValue);
       }, done));
     })
+    
+    it('continues listening to changed objects', function(done){
+      o.newlyAddedObject = { x: [[{woot: true}]]};
+      ee.deliverChanges();
+      o.newlyAddedObject = { x: [[{ woot: true }]] };
+      
+      ee.once('change newlyAddedObject', function(change){
+        o.newlyAddedObject.x[0][0].woot = false;
+      });
+  
+      ee.once('update newlyAddedObject.x.0.0.woot', t(function(change){
+        assert.strictEqual(false, change.value);
+        assert.strictEqual(true, change.oldValue);
+      }, done));
+    })
   })
 
   it('stops listening to deleted properties', function(done){

--- a/test/index.js
+++ b/test/index.js
@@ -249,6 +249,21 @@ describe('observed', function(){
         assert.strictEqual(true, change.oldValue);
       }, done));
     })
+    
+   it('continues listening to changed arrays', function(done){
+      o.newlyAddedObject = [{ x: [[{woot: true}]]}];
+      ee.deliverChanges();
+      o.newlyAddedObject = [{ x: [[{ woot: true }]] }];
+      
+      ee.once('change newlyAddedObject', function(change){
+        o.newlyAddedObject[0].x[0][0].woot = false;
+      });
+  
+      ee.once('update newlyAddedObject.0.x.0.0.woot', t(function(change){
+        assert.strictEqual(false, change.value);
+        assert.strictEqual(true, change.oldValue);
+      }, done));
+    })
   })
 
   it('stops listening to deleted properties', function(done){


### PR DESCRIPTION
This demo code fails with the current version:
```JavaScript
var O = require("observed");
var obj = {};
var ee = O(obj);
ee.on("change", console.log.bind(console));

obj.x = {arr: []}; // Add event is fired.
obj.x.arr.push(1); // Add is fired with path x.arr.0
obj.x = {arr: []}; // Change event is fired.
obj.x.arr.push(1); // No event is fired here.
```

This seems a bit inconsistent with the observer model considering that this works:
```JavaScript
var O = require("observed");
var obj = {};
var ee = O(obj);
ee.on("change", console.log.bind(console));

obj.x = {arr: []}; // Add event is fired.
obj.x.arr.push(1); // Add is fired with path x.arr.0
delete obj.x; // Delete event is fired.
obj.x = {arr: []}; // Change event is fired.
obj.x.arr.push(1); // Add is fired with path x.arr.0.
```

This pull request fixes that by monitoring the `update` besides the already-monitored `add` change in the `onchange` function to register new observers and forget about old ones. It also adds tests to confirm these changes work.