### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#observed
+# observed
 
 **ABANDONED 4/22/2016** Object.observe has been [removed from future versions of V8](https://github.com/v8/v8/commit/6a370a6f01b004f0b359aa0e0ce4aa90d40773d0). Therefore, this module is no longer being maintained.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
